### PR TITLE
Fix bashisms, download using HTTPS

### DIFF
--- a/sc3u-2.0a-x86.run.patch
+++ b/sc3u-2.0a-x86.run.patch
@@ -6,11 +6,11 @@
 +skip=180
  # This script was generated using Makeself 1.5.4
 -CRCsum=2069455402
-+CRCsum=1151330528
++CRCsum=838330230
  MD5=00000000000000000000000000000000
  label="SimCity 3000 Unlimited 2.0a Update"
 -script=./update.sh
-+if [ `uname -m` == "x86_64" ]; then
++if test `uname -m` = 'x86_64'; then
 +  script="linux32 ./update.sh"
 +else
 +  script=./update.sh

--- a/sc3u-patcher.sh
+++ b/sc3u-patcher.sh
@@ -6,15 +6,15 @@ SC3U_PATH='/usr/local/games/SC3U'
 # Check for required programs
 RPROGRAMS="curl cat patch tar"
 for RPROGRAM in ${RPROGRAMS}; do
-  if [ "$(which ${RPROGRAM} &> /dev/null; echo ${?})" != "0" ]; then
+  if test "$(which ${RPROGRAM})" = ''; then
     echo "ERROR: Required binary ${RPROGRAM} not found. Install it to proceed"
     exit 1
   fi
 done
 
 # Download sc3u patch
-if [ ! -f ${PATCH_FNAME} ]; then
-  curl http://updates.lokigames.com/sc3u/${PATCH_FNAME} -o ${PATCH_FNAME}
+if test ! -f ${PATCH_FNAME}; then
+  curl -L https://updates.lokigames.com/sc3u/${PATCH_FNAME} -o ${PATCH_FNAME}
 fi
 
 # Fix compatibility problems
@@ -37,8 +37,8 @@ sudo cp sc3u ${SC3U_PATH}/sc3u
 sudo chmod +x ${SC3U_PATH}/sc3u
 
 # Download and install loki compat libary
-if [ ! -f ${LOKI_COMPAT} ]; then
-  curl http://www.improbability.net/loki/${LOKI_COMPAT} -o ${LOKI_COMPAT}
+if test ! -f ${LOKI_COMPAT}; then
+  curl -L https://www.improbability.net/loki/${LOKI_COMPAT} -o ${LOKI_COMPAT}
 fi
 sudo tar -xjf ${LOKI_COMPAT} -C ${SC3U_PATH}
 

--- a/sc3u-patcher.sh
+++ b/sc3u-patcher.sh
@@ -6,7 +6,7 @@ SC3U_PATH='/usr/local/games/SC3U'
 # Check for required programs
 RPROGRAMS="curl cat patch tar"
 for RPROGRAM in ${RPROGRAMS}; do
-  if test "$(which ${RPROGRAM})" = ''; then
+  if test `which ${RPROGRAM}` = ''; then
     echo "ERROR: Required binary ${RPROGRAM} not found. Install it to proceed"
     exit 1
   fi


### PR DESCRIPTION
Fixes https://github.com/juliogonzalez/sc3u-linux/issues/4

- Avoid using bash specifics, as in the end this is all being run with `/bin/sh`
- The patch on Lokigames was downloaded using HTTP, but now HTTPS is enforced by using a link so:
  - Always use HTTPS
  - Follow links in case the file gets moved later to another location.
  - Do the same for the Loki Compat tarball.

@greyscale42, I don't have Sim City 3000 installed or available right now, so I could test downloading the patch and patching the path, but not the rest.

Would you mind giving this a try? You just need to use the branch `remove-bashisms` instead of `master`
